### PR TITLE
Removed AppKit import.

### DIFF
--- a/Sources/AsyncPlus/Node.swift
+++ b/Sources/AsyncPlus/Node.swift
@@ -1,5 +1,4 @@
 import Foundation
-import AppKit
 
 public protocol Node {
     associatedtype T


### PR DESCRIPTION
This import is preventing the library being used in iOS projects.